### PR TITLE
ReverseGeocode thread-safety

### DIFF
--- a/rgeo_test.go
+++ b/rgeo_test.go
@@ -263,6 +263,7 @@ func TestReverseGeocode_Countries(t *testing.T) {
 	if testing.Short() {
 		t.Skip("Skipping integration test (countries) for short mode")
 	}
+	t.Parallel()
 
 	for _, dataset := range []func() []byte{Countries110, Countries10} {
 		r, err := New(dataset)
@@ -278,6 +279,8 @@ func TestReverseGeocode_Countries(t *testing.T) {
 			test.expected.City = ""
 
 			t.Run(test.name, func(t *testing.T) {
+				t.Parallel()
+
 				result, err := r.ReverseGeocode(test.in)
 				if err != test.err {
 					t.Errorf("expected error: %s\n got: %s\n", test.err, err)
@@ -294,6 +297,7 @@ func TestReverseGeocode_Provinces(t *testing.T) {
 	if testing.Short() {
 		t.Skip("Skipping integraion test (provinces) in short mode")
 	}
+	t.Parallel()
 
 	r, err := New(Provinces10)
 	if err != nil {
@@ -306,6 +310,8 @@ func TestReverseGeocode_Provinces(t *testing.T) {
 		test.expected.City = ""
 
 		t.Run(test.name, func(t *testing.T) {
+			t.Parallel()
+
 			result, err := r.ReverseGeocode(test.in)
 			if err != test.err {
 				t.Errorf("expected error: %s\n got: %s\n", test.err, err)
@@ -321,6 +327,7 @@ func TestReverseGeocode_Cities(t *testing.T) {
 	if testing.Short() {
 		t.Skip("Skipping integration test (cities) in short mode.")
 	}
+	t.Parallel()
 
 	r, err := New(Provinces10, Cities10)
 	if err != nil {
@@ -330,6 +337,8 @@ func TestReverseGeocode_Cities(t *testing.T) {
 	for _, test := range testdata {
 		test := test
 		t.Run(test.name, func(t *testing.T) {
+			t.Parallel()
+
 			result, err := r.ReverseGeocode(test.in)
 			if err != test.err {
 				t.Errorf("expected error: %s\n got: %s\n", test.err, err)


### PR DESCRIPTION
Currently, concurrent calls to `ReverseGeocode` will have undefined results due to iterator reuse between concurrent calls. The devil is in the detail, specifically a comment on `s2.ContainsPointQuery` mentions that:
> This type is not safe for concurrent use.

The Go race detector does not find this issue by default, because tests are not parallelized. I add a separate commit to parallelize the tests and thus enable detection of the issue via `go test -count=1 -race -run=TestReverseGeocode_Countries`:
```
$ go test -count=1 -race -run=TestReverseGeocode_Countries
==================
WARNING: DATA RACE
Write at 0x00c000431628 by goroutine 28:
  github.com/golang/geo/s2.(*ShapeIndexIterator).seek()
      /Users/okuckertz/go/pkg/mod/github.com/golang/geo@v0.0.0-20230421003525-6adc56603217/s2/shapeindex.go:315 +0xf3
  github.com/golang/geo/s2.(*ShapeIndexIterator).LocatePoint()
      /Users/okuckertz/go/pkg/mod/github.com/golang/geo@v0.0.0-20230421003525-6adc56603217/s2/shapeindex.go:331 +0x70
  github.com/golang/geo/s2.(*ContainsPointQuery).visitContainingShapes()
      /Users/okuckertz/go/pkg/mod/github.com/golang/geo@v0.0.0-20230421003525-6adc56603217/s2/contains_point_query.go:164 +0x89
  github.com/golang/geo/s2.(*ContainsPointQuery).ContainingShapes()
      /Users/okuckertz/go/pkg/mod/github.com/golang/geo@v0.0.0-20230421003525-6adc56603217/s2/contains_point_query.go:181 +0xa4
  github.com/sams96/rgeo.(*Rgeo).ReverseGeocode()
      /Users/okuckertz/Devel/AV/rgeo/rgeo.go:160 +0xf0
  github.com/sams96/rgeo.TestReverseGeocode_Countries.func1()
      /Users/okuckertz/Devel/AV/rgeo/rgeo_test.go:284 +0xad
  testing.tRunner()
      /usr/local/Cellar/go/1.22.4/libexec/src/testing/testing.go:1689 +0x21e
  testing.(*T).Run.gowrap1()
      /usr/local/Cellar/go/1.22.4/libexec/src/testing/testing.go:1742 +0x44
[...]
```

### Solution

The issue can be avoided by simply constructing a new query for every lookup.

### Performance evaluation

I found that this change does not impact test runtime, because `ShapeIndex` internally optimizes to build the index only once for the first query in a thread-safe manner. Unchanged timing can be verified via `time go test -count=1 -parallel=1`.

However, due to changed timing of `New` and the first `ReverseGeocode` call, this merge request should not land in a patch but rather a minor release with appropriate release notes that mention this detail. A new `Build` method is added to expose `ShapeIndex.Build` if the user wants to avoid indexing overhead with the first lookup. 

Best,
Oliver